### PR TITLE
Add text coloring markup parser

### DIFF
--- a/Assets/testing/scripts/scroll_test.cs
+++ b/Assets/testing/scripts/scroll_test.cs
@@ -135,7 +135,7 @@ public class scroll_test : MonoBehaviour
 
             double rand = r.NextDouble();
             string newLine = "";
-            if(rand < 0.8)
+            if(rand < 0.65)
             {
                 newLine = string.Join("", Enumerable.Range(0, engine.WidthChars)
                     .Select(cur => r.NextDouble() <= percentFull ? string.Format("<c{0}{1}{2}>", 
@@ -144,7 +144,7 @@ public class scroll_test : MonoBehaviour
                     (char)(r.Next(26) + 'a')) : " ")
                     .ToArray());
             }
-            else if (rand < 0.7)
+            else if (rand < 0.75)
             {
                 newLine = string.Format("<c{0}{1}this is a colored string>", fgColor, bgColor);
             }

--- a/Assets/testing/scripts/scroll_test.cs
+++ b/Assets/testing/scripts/scroll_test.cs
@@ -132,7 +132,8 @@ public class scroll_test : MonoBehaviour
         {
             string newLine = string.Join("", Enumerable.Range(0, engine.WidthChars)
                 .Select(cur => r.NextDouble() <= percentFull ?
-                        string.Format("`{0}{1}`", 
+                        string.Format("<c{0}{1}{2}>", 
+                                      u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key,
                                       u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key,
                                       (char)(r.Next(26) + 'a')) :
                         " ").ToArray());

--- a/Assets/testing/scripts/scroll_test.cs
+++ b/Assets/testing/scripts/scroll_test.cs
@@ -130,13 +130,46 @@ public class scroll_test : MonoBehaviour
 
         while (accumulator > msPerLine)
         {
-            string newLine = string.Join("", Enumerable.Range(0, engine.WidthChars)
-                .Select(cur => r.NextDouble() <= percentFull ?
-                        string.Format("<c{0}{1}{2}>", 
-                                      u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key,
-                                      u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key,
-                                      (char)(r.Next(26) + 'a')) :
-                        " ").ToArray());
+            char fgColor = u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key;
+            char bgColor = u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key;
+
+            double rand = r.NextDouble();
+            string newLine = "";
+            if(rand < 0.8)
+            {
+                newLine = string.Join("", Enumerable.Range(0, engine.WidthChars)
+                    .Select(cur => r.NextDouble() <= percentFull ? string.Format("<c{0}{1}{2}>", 
+                    u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key, 
+                    u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key, 
+                    (char)(r.Next(26) + 'a')) : " ")
+                    .ToArray());
+            }
+            else if (rand < 0.7)
+            {
+                newLine = string.Format("<c{0}{1}this is a colored string>", fgColor, bgColor);
+            }
+            else if (rand < 0.85)
+            {
+                char fgColor2 = u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key;
+                char bgColor2 = u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key;
+
+                newLine = string.Format("<c{0}{1}this is a <c{2}{3}broken nested color string>", fgColor, bgColor, fgColor2, bgColor2);
+            }
+            else if (rand < 0.95)
+            {
+                char fgColor2 = u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key;
+                char bgColor2 = u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key;
+
+                newLine = string.Format("<c{0}{1}this is a <c{2}{3}doubly <c{4}{5}broken nested color string>", fgColor, bgColor, fgColor2, bgColor2, fgColor, fgColor2);
+            }
+            else
+            {
+                char fgColor2 = u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key;
+                char bgColor2 = u3d_text_3ngine.HackmudColors.ElementAt(r.Next(u3d_text_3ngine.HackmudColors.Count)).Key;
+
+                newLine = string.Format("<c{0}{1}this is a <c{2}{3}nested> colored string>", fgColor, bgColor, fgColor2, bgColor2);
+            }
+            
 
             engine.DisplayText = engine.DisplayText.Skip(1).Concat(new string[] { newLine }).ToArray();
 


### PR DESCRIPTION
Closes #3 

Format: `<cFBtext>` where F and B are valid hackmud color codes for foreground and background coloring, or wildcard (see below).  Note: background coloring is currently not implemented, but the parser provides the information so it can be rendered.

Supports nesting, escaping via `\`, wildcard to preserve prior coloring via `*`, and defaults to "plain text" output if tags are malformed or non-closing.

This uses a two pass system to detect unclosed tags.

I get a full 60fps when running the updated tests, see [this image](https://i.imgur.com/jVYJgqh.png)